### PR TITLE
feat: 추가적인 보안 설정 및 에러 페이지 비활성화

### DIFF
--- a/backend/src/main/java/com/jjajo/presentation/config/SecurityConfig.java
+++ b/backend/src/main/java/com/jjajo/presentation/config/SecurityConfig.java
@@ -68,6 +68,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(authorize -> authorize
                 .requestMatchers(
                     "/",
+                    "/error",
                     "/swagger-ui.html",
                     "/swagger-ui/**",
                     "/api-docs/**",

--- a/backend/src/main/java/com/jjajo/presentation/controller/CustomErrorController.java
+++ b/backend/src/main/java/com/jjajo/presentation/controller/CustomErrorController.java
@@ -1,0 +1,54 @@
+package com.jjajo.presentation.controller;
+
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.servlet.error.ErrorController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.util.Map;
+
+/**
+ * Whitelabel 대신 404 시 프론트로 리다이렉트.
+ * Spring Boot가 /error 로 포워드한 뒤 이 컨트롤러가 처리한다.
+ */
+@Controller
+public class CustomErrorController implements ErrorController {
+
+    @Value("${app.frontend-origin:http://localhost:5173}")
+    private String frontendOrigin;
+
+    @RequestMapping("${server.error.path:/error}")
+    @ResponseBody
+    public Object handleError(HttpServletRequest request) {
+        Object statusObj = request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
+        int status = statusObj != null ? Integer.parseInt(statusObj.toString()) : 500;
+        String path = request.getAttribute(RequestDispatcher.ERROR_REQUEST_URI) != null
+            ? request.getAttribute(RequestDispatcher.ERROR_REQUEST_URI).toString()
+            : "";
+
+        String accept = request.getHeader("Accept") != null ? request.getHeader("Accept") : "";
+        boolean isBrowser = !path.startsWith("/api") && !accept.contains(MediaType.APPLICATION_JSON_VALUE);
+
+        if (status == 404 && isBrowser) {
+            String target = (frontendOrigin != null && !frontendOrigin.isEmpty())
+                ? frontendOrigin.replaceAll("/$", "") + "/"
+                : "http://localhost:5173/";
+            return ResponseEntity.status(HttpStatus.FOUND).location(java.net.URI.create(target)).build();
+        }
+
+        if (path.startsWith("/api") || accept.contains(MediaType.APPLICATION_JSON_VALUE)) {
+            return ResponseEntity
+                .status(status)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(Map.of("error", "Error", "status", status, "path", path));
+        }
+
+        return ResponseEntity.status(status).body("Error " + status);
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 server:
-  # 프록시(Render 등) 뒤에서 redirect_uri가 https로 생성되도록 X-Forwarded-Proto/Host 적용
   forward-headers-strategy: framework
+  error:
+    whitelabel:
+      enabled: false
 
 spring:
   application:


### PR DESCRIPTION
- SecurityConfig에서 '/error' 경로를 허용하여 에러 페이지 접근을 지원.
- application.yml에서 Whitelabel 에러 페이지를 비활성화하여 사용자 정의 에러 페이지 사용 가능.