### PR TITLE
feat: 프론트엔드 오리진 처리 개선 및 CORS 설정 통일

### DIFF
--- a/backend/src/main/java/com/jjajo/presentation/config/FrontendOriginNormalizer.java
+++ b/backend/src/main/java/com/jjajo/presentation/config/FrontendOriginNormalizer.java
@@ -1,0 +1,24 @@
+package com.jjajo.presentation.config;
+
+/**
+ * FRONTEND_ORIGIN이 스킴 없이(예: jjajo.pages.dev) 설정되면
+ * sendRedirect가 상대 URL로 처리되어 백엔드 호스트 뒤에 경로가 반복 붙는 문제를 방지.
+ * 항상 절대 URL(https://...)으로 변환한다.
+ */
+public final class FrontendOriginNormalizer {
+
+    /**
+     * null/빈 값이거나 http(s)로 시작하지 않으면 https:// 를 붙여 절대 URL로 반환.
+     * 끝의 슬래시는 제거 (리다이렉트 시 호출하는 쪽에서 "/" 추가).
+     */
+    public static String toAbsoluteUrl(String frontendOrigin) {
+        if (frontendOrigin == null || frontendOrigin.isEmpty()) {
+            return "http://localhost:5173";
+        }
+        String s = frontendOrigin.trim();
+        if (!s.startsWith("http://") && !s.startsWith("https://")) {
+            s = "https://" + s;
+        }
+        return s.replaceAll("/+$", "");
+    }
+}

--- a/backend/src/main/java/com/jjajo/presentation/config/GlobalErrorHandler.java
+++ b/backend/src/main/java/com/jjajo/presentation/config/GlobalErrorHandler.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.servlet.NoHandlerFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.jjajo.presentation.config.FrontendOriginNormalizer;
 
 import java.util.Map;
 
@@ -40,9 +41,7 @@ public class GlobalErrorHandler {
                 .body(Map.of("error", "Not Found", "path", path));
         }
 
-        String target = (frontendOrigin != null && !frontendOrigin.isEmpty())
-            ? frontendOrigin.replaceAll("/$", "") + "/"
-            : "http://localhost:5173/";
+        String target = FrontendOriginNormalizer.toAbsoluteUrl(frontendOrigin) + "/";
         // #region agent log
         try {
             String backendHost = request.getServerName() != null ? request.getServerName().toLowerCase() : "";

--- a/backend/src/main/java/com/jjajo/presentation/config/SecurityConfig.java
+++ b/backend/src/main/java/com/jjajo/presentation/config/SecurityConfig.java
@@ -114,7 +114,7 @@ public class SecurityConfig {
     @Bean
     public AuthenticationSuccessHandler redirectToFrontendSuccessHandler() {
         return (request, response, authentication) -> {
-            String target = frontendOrigin != null ? frontendOrigin : "http://localhost:5173";
+            String target = FrontendOriginNormalizer.toAbsoluteUrl(frontendOrigin);
             if (!target.endsWith("/")) {
                 target = target + "/";
             }
@@ -275,7 +275,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowCredentials(true);
-        configuration.setAllowedOrigins(List.of(frontendOrigin));
+        configuration.setAllowedOrigins(List.of(FrontendOriginNormalizer.toAbsoluteUrl(frontendOrigin)));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "X-Requested-With", "Accept", "Origin", "X-Gemini-API-Key"));
 

--- a/backend/src/main/java/com/jjajo/presentation/controller/CustomErrorController.java
+++ b/backend/src/main/java/com/jjajo/presentation/controller/CustomErrorController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.jjajo.presentation.config.FrontendOriginNormalizer;
 
 import java.util.Map;
 
@@ -40,9 +41,7 @@ public class CustomErrorController implements ErrorController {
         boolean isBrowser = !path.startsWith("/api") && !accept.contains(MediaType.APPLICATION_JSON_VALUE);
 
         if (status == 404 && isBrowser) {
-            String target = (frontendOrigin != null && !frontendOrigin.isEmpty())
-                ? frontendOrigin.replaceAll("/$", "") + "/"
-                : "http://localhost:5173/";
+            String target = FrontendOriginNormalizer.toAbsoluteUrl(frontendOrigin) + "/";
             // #region agent log
             try {
                 String backendHost = request.getServerName() != null ? request.getServerName().toLowerCase() : "";

--- a/backend/src/main/java/com/jjajo/presentation/controller/GoalController.java
+++ b/backend/src/main/java/com/jjajo/presentation/controller/GoalController.java
@@ -6,6 +6,7 @@ import com.jjajo.domain.entity.MilestoneEntity;
 import com.jjajo.domain.model.Goal;
 import com.jjajo.domain.model.Milestone;
 import com.jjajo.domain.repository.GoalRepository;
+import com.jjajo.presentation.config.FrontendOriginNormalizer;
 import com.jjajo.presentation.config.SecurityConfig;
 import com.jjajo.presentation.dto.GoalCreationRequest;
 import com.jjajo.presentation.dto.GoalCreationResponse;
@@ -52,7 +53,7 @@ public class GoalController {
     public void optionsGoals(HttpServletResponse response) {
         response.setStatus(HttpServletResponse.SC_OK);
         if (frontendOrigin != null && !frontendOrigin.isEmpty()) {
-            response.setHeader("Access-Control-Allow-Origin", frontendOrigin);
+            response.setHeader("Access-Control-Allow-Origin", FrontendOriginNormalizer.toAbsoluteUrl(frontendOrigin));
         }
         response.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
         response.setHeader("Access-Control-Allow-Headers", "Authorization, Content-Type, X-Requested-With, Accept, Origin, X-Gemini-API-Key");

--- a/backend/src/main/java/com/jjajo/presentation/controller/OAuthDebugController.java
+++ b/backend/src/main/java/com/jjajo/presentation/controller/OAuthDebugController.java
@@ -2,6 +2,7 @@ package com.jjajo.presentation.controller;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
+import com.jjajo.presentation.config.FrontendOriginNormalizer;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,8 +26,9 @@ public class OAuthDebugController {
     @GetMapping("/frontend-origin")
     public ResponseEntity<Map<String, String>> frontendOrigin() {
         Map<String, String> body = new HashMap<>();
-        body.put("frontend_origin", frontendOrigin != null ? frontendOrigin : "(null)");
-        body.put("hint", "OAuth 성공 후 이 URL로 리다이렉트됩니다. 백엔드 URL과 같으면 ERR_TOO_MANY_REDIRECTS 발생. Render 환경변수 FRONTEND_ORIGIN을 실제 프론트엔드 URL로 설정하세요.");
+        body.put("frontend_origin_raw", frontendOrigin != null ? frontendOrigin : "(null)");
+        body.put("frontend_origin_normalized", FrontendOriginNormalizer.toAbsoluteUrl(frontendOrigin));
+        body.put("hint", "스킴 없이(예: jjajo.pages.dev) 넣어도 내부에서 https:// 로 변환됩니다. 반드시 전체 URL(https://jjajo.pages.dev)으로 넣는 것을 권장합니다.");
         return ResponseEntity.ok(body);
     }
 


### PR DESCRIPTION
- GlobalErrorHandler, SecurityConfig, CustomErrorController, GoalController에서 frontendOrigin을 FrontendOriginNormalizer를 사용하여 절대 URL로 변환.
- OAuthDebugController에 프론트엔드 오리진의 정규화된 값을 반환하는 API 추가로 디버깅 지원 강화.